### PR TITLE
fix: 사용되지 않는 include 파일경로 제거

### DIFF
--- a/apps/portfolio/tsconfig.json
+++ b/apps/portfolio/tsconfig.json
@@ -6,6 +6,6 @@
       "~/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
nextjs에서 gatsby로 migration하는 과정에서 남은 잔재로 보입니다